### PR TITLE
OJ-2801: Adds pre-merge github actions

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -1,0 +1,24 @@
+name: Check PR
+
+on: pull_request
+permissions: {}
+
+jobs:
+  pre-commit:
+    name: pre-commit
+    runs-on: ubuntu-latest
+    concurrency:
+      group: pre-commit-${{ github.head_ref || github.ref_name }}
+      cancel-in-progress: true
+    steps:
+      - name: Run pre-commit
+        uses: govuk-one-login/github-actions/code-quality/run-pre-commit@3b8133beab89c813cf15375904be82bf9ab79a91
+        with:
+          all-files: true
+
+  deploy:
+    name: Preview
+    uses: ./.github/workflows/deploy-branch.yml
+    permissions:
+      id-token: write
+      contents: read

--- a/.github/workflows/clean-up-deployments.yml
+++ b/.github/workflows/clean-up-deployments.yml
@@ -1,0 +1,44 @@
+name: Clean up deployments
+run-name: Delete stale deployments
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Every weekday at 10am
+    - cron: "0 10 * * 1-5"
+
+permissions:
+  id-token: write
+  contents: read
+
+concurrency: cleanup-dev-${{ github.head_ref || github.ref_name }}
+
+jobs:
+  delete-stacks:
+    name: Delete stale stacks
+    runs-on: ubuntu-latest
+    environment: development
+    steps:
+      - name: Assume AWS Role
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.DEPLOYMENT_ROLE_ARN }}
+          aws-region: eu-west-2
+
+      - name: Get stale preview stacks
+        uses: govuk-one-login/github-actions/sam/get-stale-stacks@3b8133beab89c813cf15375904be82bf9ab79a91
+        with:
+          threshold-days: 14
+          stack-name-filter: st
+          stack-tag-filters: |
+            cri:deployment-source=github-actions
+            cri:stack-type=preview
+          description: preview
+          env-var-name: STACKS
+
+      - name: Delete stacks
+        if: ${{ env.STACKS != null }}
+        uses: govuk-one-login/github-actions/sam/delete-stacks@3b8133beab89c813cf15375904be82bf9ab79a91
+        with:
+          stack-names: ${{ env.STACKS }}
+          verbose: true

--- a/.github/workflows/delete-deployment.yml
+++ b/.github/workflows/delete-deployment.yml
@@ -1,0 +1,36 @@
+name: Delete deployment
+run-name: ${{ github.event.pull_request.title || format('Delete deployment [{0}]', github.head_ref || github.ref_name) }}
+
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [closed]
+
+permissions:
+  id-token: write
+  contents: read
+
+concurrency: deploy-development-${{ github.head_ref || github.ref_name }}
+
+jobs:
+  delete-stack:
+    name: Delete stack
+    runs-on: ubuntu-latest
+    environment: development
+
+    steps:
+      - name: Get stack name
+        uses: govuk-one-login/github-actions/beautify-branch-name@3b8133beab89c813cf15375904be82bf9ab79a91
+        id: get-stack-name
+        with:
+          usage: Stack name
+          prefix: st
+          length-limit: 15
+          verbose: false
+
+      - name: Delete stack
+        uses: govuk-one-login/github-actions/sam/delete-stacks@3b8133beab89c813cf15375904be82bf9ab79a91
+        with:
+          stack-names: ${{ steps.get-stack-name.outputs.pretty-branch-name }}
+          aws-role-arn: ${{ vars.DEPLOYMENT_ROLE_ARN }}
+          verbose: true

--- a/.github/workflows/deploy-branch.yml
+++ b/.github/workflows/deploy-branch.yml
@@ -1,0 +1,69 @@
+name: Deploy preview
+
+on:
+  workflow_dispatch:
+  workflow_call:
+    outputs:
+      stack-name:
+        description: The deployed stack name
+        value: ${{ jobs.deploy.outputs.stack-name }}
+      aws-region:
+        description: The region in which the stack was deployed
+        value: ${{ jobs.deploy.outputs.aws-region }}
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  build:
+    name: Build SAM app
+    runs-on: ubuntu-latest
+    permissions: {}
+    outputs:
+      cache-key: ${{ steps.build.outputs.cache-key }}
+      cache-restore-keys: ${{ steps.build.outputs.cache-restore-keys }}
+    steps:
+      - name: Build SAM application
+        uses: govuk-one-login/github-actions/sam/build-application@3b8133beab89c813cf15375904be82bf9ab79a91
+        id: build
+        with:
+          template: infrastructure/template.yaml
+          cache-name: otg-smoke-tests
+          pull-repository: true
+          source-dir: lambdas
+
+  deploy:
+    name: Deploy stack
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: build
+    concurrency:
+      group: deploy-development-${{ github.head_ref || github.ref_name }}
+    environment:
+      name: development
+      url: ${{ steps.deploy.outputs.stack-url }}
+    outputs:
+      aws-region: ${{ steps.deploy.outputs.aws-region }}
+      stack-name: ${{ steps.deploy.outputs.stack-name }}
+    steps:
+      - name: Deploy stack
+        uses: govuk-one-login/github-actions/sam/deploy-stack@3b8133beab89c813cf15375904be82bf9ab79a91
+        id: deploy
+        with:
+          sam-deployment-bucket: ${{ vars.DEPLOYMENT_ARTIFACTS_BUCKET }}
+          aws-role-arn: ${{ vars.DEPLOYMENT_ROLE_ARN }}
+          stack-name-prefix: st
+          cache-key: ${{ needs.build.outputs.cache-key }}
+          cache-restore-keys: ${{ needs.build.outputs.cache-restore-keys }}
+          s3-prefix: smoke-tests
+          pull-repository: true
+          delete-failed-stack: true
+          stack-name-length-limit: 15
+          tags: |
+            cri:component=ipv-cri-otg-smoke-tests
+            cri:stack-type=preview
+            cri:application=Orange
+            cri:deployment-source=github-actions
+          parameters: |
+            Environment=dev

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -117,7 +117,7 @@ Resources:
   OTGCanaries:
     Type: AWS::Synthetics::Canary
     Properties:
-      Name: get-bearer-token
+      Name: !Sub ${AWS::StackName}-ci
       StartCanaryAfterCreation: true
       ArtifactS3Location: !Sub s3://${CanariesBucket}/ci
       ExecutionRoleArn: !GetAtt CanariesRole.Arn


### PR DESCRIPTION
## Proposed changes

### What changed

Added pre-merge github actions. Note that the delete and cleanup workflows are failing due to this bug https://govukverify.atlassian.net/browse/OJ-2824

Relevant variables have been added to github

### Why did it change

Needed to ensure the quality of code being merged into the repo

### Screenshots

Preview stack deploys correctly
<img width="1110" alt="image" src="https://github.com/user-attachments/assets/9179e6a6-df2b-46e9-98cc-286d599c29b5">

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-2801](https://govukverify.atlassian.net/browse/OJ-2801)



[OJ-2801]: https://govukverify.atlassian.net/browse/OJ-2801?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ