### PR TITLE
OJ-2801: Ensure globally unique name for the canaries bucket

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -92,7 +92,13 @@ Resources:
   CanariesBucket:
     Type: AWS::S3::Bucket
     Properties:
-      BucketName: !Sub ${AWS::StackName}-otg-canaries-bucket
+      VersioningConfiguration:
+        Status: Enabled
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
 
   CanaryInvokerFunction:
     Type: AWS::Serverless::Function


### PR DESCRIPTION
OJ-2801: Ensure globally unique name for the canaries bucket

Don't specify the bucket name to let CloudFormation create a unique name and prevent name clashes between accounts.

Add security flags to the bucket.