### PR TITLE
OJ-2824: Empty buckets before deleting a stack

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -12,7 +12,7 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Run pre-commit
-        uses: govuk-one-login/github-actions/code-quality/run-pre-commit@3b8133beab89c813cf15375904be82bf9ab79a91
+        uses: govuk-one-login/github-actions/code-quality/run-pre-commit@d201191485b645ec856a34e5ca48636cf97b2574
         with:
           all-files: true
 

--- a/.github/workflows/clean-up-deployments.yml
+++ b/.github/workflows/clean-up-deployments.yml
@@ -14,31 +14,41 @@ permissions:
 concurrency: cleanup-dev-${{ github.head_ref || github.ref_name }}
 
 jobs:
-  delete-stacks:
-    name: Delete stale stacks
+  get-stale-stacks:
+    name: Get stale stacks
     runs-on: ubuntu-latest
     environment: development
+    outputs:
+      stacks: ${{ steps.get-stacks.outputs.stack-names-json }}
     steps:
-      - name: Assume AWS Role
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ vars.DEPLOYMENT_ROLE_ARN }}
-          aws-region: eu-west-2
-
       - name: Get stale preview stacks
-        uses: govuk-one-login/github-actions/sam/get-stale-stacks@3b8133beab89c813cf15375904be82bf9ab79a91
+        uses: govuk-one-login/github-actions/sam/get-stale-stacks@d201191485b645ec856a34e5ca48636cf97b2574
+        id: get-stacks
         with:
+          aws-role-arn: ${{ vars.DEPLOYMENT_ROLE_ARN }}
           threshold-days: 14
           stack-name-filter: st
           stack-tag-filters: |
             cri:deployment-source=github-actions
             cri:stack-type=preview
           description: preview
-          env-var-name: STACKS
 
-      - name: Delete stacks
-        if: ${{ env.STACKS != null }}
-        uses: govuk-one-login/github-actions/sam/delete-stacks@3b8133beab89c813cf15375904be82bf9ab79a91
+  delete-stacks:
+    name: Delete ${{ matrix.stack }}
+    needs: get-stale-stacks
+    runs-on: ubuntu-latest
+    environment: development
+    if: ${{ needs.get-stale-stacks.outputs.stacks != '[]' }}
+    strategy:
+      max-parallel: 5
+      fail-fast: false
+      matrix:
+        stack: ${{ fromJSON(needs.get-stale-stacks.outputs.stacks) }}
+    steps:
+      - name: Delete stack
+        uses: govuk-one-login/github-actions/sam/delete-stacks@d201191485b645ec856a34e5ca48636cf97b2574
         with:
-          stack-names: ${{ env.STACKS }}
+          aws-role-arn: ${{ vars.DEPLOYMENT_ROLE_ARN }}
+          stack-names: ${{ matrix.stack }}
+          empty-buckets: true
           verbose: true

--- a/.github/workflows/delete-deployment.yml
+++ b/.github/workflows/delete-deployment.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Get stack name
-        uses: govuk-one-login/github-actions/beautify-branch-name@3b8133beab89c813cf15375904be82bf9ab79a91
+        uses: govuk-one-login/github-actions/beautify-branch-name@d201191485b645ec856a34e5ca48636cf97b2574
         id: get-stack-name
         with:
           usage: Stack name

--- a/.github/workflows/delete-deployment.yml
+++ b/.github/workflows/delete-deployment.yml
@@ -29,8 +29,9 @@ jobs:
           verbose: false
 
       - name: Delete stack
-        uses: govuk-one-login/github-actions/sam/delete-stacks@3b8133beab89c813cf15375904be82bf9ab79a91
+        uses: govuk-one-login/github-actions/sam/delete-stacks@d201191485b645ec856a34e5ca48636cf97b2574
         with:
           stack-names: ${{ steps.get-stack-name.outputs.pretty-branch-name }}
           aws-role-arn: ${{ vars.DEPLOYMENT_ROLE_ARN }}
+          empty-buckets: true
           verbose: true

--- a/.github/workflows/deploy-branch.yml
+++ b/.github/workflows/deploy-branch.yml
@@ -25,7 +25,7 @@ jobs:
       cache-restore-keys: ${{ steps.build.outputs.cache-restore-keys }}
     steps:
       - name: Build SAM application
-        uses: govuk-one-login/github-actions/sam/build-application@3b8133beab89c813cf15375904be82bf9ab79a91
+        uses: govuk-one-login/github-actions/sam/build-application@d201191485b645ec856a34e5ca48636cf97b2574
         id: build
         with:
           template: infrastructure/template.yaml
@@ -48,7 +48,7 @@ jobs:
       stack-name: ${{ steps.deploy.outputs.stack-name }}
     steps:
       - name: Deploy stack
-        uses: govuk-one-login/github-actions/sam/deploy-stack@3b8133beab89c813cf15375904be82bf9ab79a91
+        uses: govuk-one-login/github-actions/sam/deploy-stack@d201191485b645ec856a34e5ca48636cf97b2574
         id: deploy
         with:
           sam-deployment-bucket: ${{ vars.DEPLOYMENT_ARTIFACTS_BUCKET }}

--- a/.github/workflows/post-merge-deploy.yml
+++ b/.github/workflows/post-merge-deploy.yml
@@ -13,7 +13,7 @@ jobs:
       cache-restore-keys: ${{ steps.build.outputs.cache-restore-keys }}
     steps:
       - name: Build SAM application
-        uses: govuk-one-login/github-actions/sam/build-application@c9c3f2ef04d9145894de83e973b0f4dc1e90d14e
+        uses: govuk-one-login/github-actions/sam/build-application@d201191485b645ec856a34e5ca48636cf97b2574
         id: build
         with:
           template: infrastructure/template.yaml

--- a/.github/workflows/push-docker-image.yml
+++ b/.github/workflows/push-docker-image.yml
@@ -29,7 +29,7 @@ jobs:
         run: exit 0
 
       - name: Push Docker image
-        uses: govuk-one-login/github-actions/aws/ecr/build-docker-image@3b8133beab89c813cf15375904be82bf9ab79a91
+        uses: govuk-one-login/github-actions/aws/ecr/build-docker-image@d201191485b645ec856a34e5ca48636cf97b2574
         if: ${{ steps.enabled.outcome == 'success' }}
         with:
           immutable-tags: false

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,12 @@
         "typescript": "^5.2.2"
       }
     },
-    "lambdas/canary-invoker": {},
+    "lambdas/canary-invoker": {
+      "extraneous": true
+    },
+    "lambdas/canary-runner": {
+      "name": "canary-invoker"
+    },
     "node_modules/@ampproject/remapping": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
@@ -4982,7 +4987,7 @@
       }
     },
     "node_modules/canary-invoker": {
-      "resolved": "lambdas/canary-invoker",
+      "resolved": "lambdas/canary-runner",
       "link": true
     },
     "node_modules/caniuse-lite": {


### PR DESCRIPTION
Set the `empty-buckets` flag to true.

Use a matrix strategy for the cleanup job to make the job pass faster, since deleting buckets can be a long-running operation.