### PR TITLE
OJ-3096: upgrade - node version runtime

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
         files: ".*\\.(js|ts)"
         pass_filenames: false
   - repo: https://github.com/aws-cloudformation/cfn-lint
-    rev: v0.86.0
+    rev: v1.27.0
     hooks:
       - id: cfn-lint
         files: .template\.ya?ml$

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -24,8 +24,8 @@ Parameters:
 Conditions:
   EnforceCodeSigning: !Not [ !Equals [ !Ref CodeSigningConfigArn, "" ] ]
   UsePermissionsBoundary: !Not [!Equals [!Ref PermissionsBoundary, ""]]
-  IsDevEnvironment: !Equals [ !Ref Environment, dev ]
-  IsLocalDevEnvironment: !Equals [ !Ref Environment, localdev ]
+  IsDevEnvironment: !Equals [ !Ref Environment, dev ] # cfn-lint: disable=W8003
+  IsLocalDevEnvironment: !Equals [ !Ref Environment, localdev ] # cfn-lint: disable=W8003
   IsDevLikeEnvironment:
     !Or [ !Condition IsLocalDevEnvironment, !Condition IsDevEnvironment ]
   IsNotDevEnvironment: !Not

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -35,7 +35,7 @@ Globals:
   Function:
     Timeout: 30
     CodeUri: ..
-    Runtime: nodejs18.x
+    Runtime: nodejs22.x
     Architectures: [ arm64 ]
     PermissionsBoundary:
       !If [UsePermissionsBoundary, !Ref PermissionsBoundary, !Ref AWS::NoValue]

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -5,7 +5,6 @@ Description: "Digital Identity IPV CRI Ipv-Cri-OTG-Hmrc-Smoke-Tests API"
 Parameters:
   Environment:
     Type: String
-    Default: dev
     AllowedValues: [ dev, localdev, build, staging, integration, production ]
     ConstraintDescription: must be dev, localdev, build, staging, integration or production
   CodeSigningConfigArn:
@@ -24,8 +23,8 @@ Parameters:
 Conditions:
   EnforceCodeSigning: !Not [ !Equals [ !Ref CodeSigningConfigArn, "" ] ]
   UsePermissionsBoundary: !Not [!Equals [!Ref PermissionsBoundary, ""]]
-  IsDevEnvironment: !Equals [ !Ref Environment, dev ] # cfn-lint: disable=W8003
-  IsLocalDevEnvironment: !Equals [ !Ref Environment, localdev ] # cfn-lint: disable=W8003
+  IsDevEnvironment: !Equals [ !Ref Environment, dev ]
+  IsLocalDevEnvironment: !Equals [ !Ref Environment, localdev ]
   IsDevLikeEnvironment:
     !Or [ !Condition IsLocalDevEnvironment, !Condition IsDevEnvironment ]
   IsNotDevEnvironment: !Not


### PR DESCRIPTION
## Proposed changes

### What changed

- Upgrade node version from 18 to 22
- Update pre-commit version
- Removed the `default: dev` in template.yaml as its passed in within the deploy.sh and samconfig.toml as a parameter override.

### Why did it change

Node 18 has reached end of active live support.
Allow SAM application to be built successfully.

### Issue tracking

- [OJ-3096](https://govukverify.atlassian.net/browse/OJ-3096)

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[OJ-3096]: https://govukverify.atlassian.net/browse/OJ-3096?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ