### PR TITLE
OJ-3671: Bump canary runtime

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -149,7 +149,7 @@ Resources:
       StartCanaryAfterCreation: true
       ArtifactS3Location: !Sub s3://${CanariesBucket}/happy
       ExecutionRoleArn: !GetAtt CanariesRole.Arn
-      RuntimeVersion: syn-nodejs-puppeteer-10.0
+      RuntimeVersion: syn-nodejs-puppeteer-13.0
       VPCConfig:
         SecurityGroupIds:
           - !ImportValue otg-vpc-AWSServicesEndpointSecurityGroupId


### PR DESCRIPTION
## Proposed changes

### What changed

Bump canary runtime version.

### Why did it change

Canary lambdas use a node20 runtime which is approaching EoL. Bump so it now uses node22.

### Issue tracking

- [OJ-3671](https://govukverify.atlassian.net/browse/OJ-3671)


[OJ-3671]: https://govukverify.atlassian.net/browse/OJ-3671?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ